### PR TITLE
Light Arrow Color on Dark Theme

### DIFF
--- a/style/ui/content.css
+++ b/style/ui/content.css
@@ -23,6 +23,10 @@
 			inline text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
 		;
 	}
+	
+	svg {
+		@apply dark:fill-gray-600;
+	}
 }
 
 .page-tool-btn svg {


### PR DESCRIPTION
Actually, the breadcrumb arrow color stays black, being pratically invisible on system dark theme.
Here you can notice the fix applied (gray arrow) and before it's apply (dark arrow):
<img width="199" alt="SCR-20250705-qtsf" src="https://github.com/user-attachments/assets/6c481701-63b1-4d93-adb5-b929b440aa8a" />
