### PR TITLE
Fix Dw2Pdf compatibility

### DIFF
--- a/style.ini
+++ b/style.ini
@@ -4,3 +4,5 @@
 
 __background__     = "#ffffff" ; @ini_background
 __background_alt__ = "#101827" ; @ini_background_alt
+__existing__       = "#1d4ed8" ; @ini_existing
+__missing__        = "#c81e1e" ; @ini_missing

--- a/style.ini
+++ b/style.ini
@@ -4,5 +4,3 @@
 
 __background__     = "#ffffff" ; @ini_background
 __background_alt__ = "#101827" ; @ini_background_alt
-__existing__       = "#1d4ed8" ; @ini_existing
-__missing__        = "#c81e1e" ; @ini_missing

--- a/style.ini
+++ b/style.ini
@@ -2,5 +2,5 @@
 
 [replacements]
 
-__background__     = ; empty
-__background_alt__ = ; empty
+__background__     = "#ffffff" ; @ini_background
+__background_alt__ = "#101827" ; @ini_background_alt


### PR DESCRIPTION
Dw2PDF calls the function ``css_styleini`` to load CSS to apply into PDF which fails  because @ini_background is empty. The export fails with the following error message:

```
.dokuwiki:before { content: 'A fatal error occured during compilation of the CSS files. If you recently installed a new plugin or template it might be broken and you should try disabling it again. [parse error: count mismatches buffer length 17 != 14723 `@ini_background: ;` ]'; background-color: red; display: block; background-color: #fcc; border-color: #ebb; color: #000; padding: 0.5em; }
```

This PR fixes the export by setting the default values for white/dark template colors into it.